### PR TITLE
[Feat] 나의 좋아요 목록 조회 기능 구현 [#2]

### DIFF
--- a/src/components/mypage/MyPageComponent.vue
+++ b/src/components/mypage/MyPageComponent.vue
@@ -63,7 +63,12 @@
                 <font-awesome-icon :icon="['fas', 'chevron-right']" />
               </p>
             </div>
-            <ul class="list_main_concert" id="perf_poster">
+
+            <div v-if="isLoading" class="loading">
+              <font-awesome-icon :icon="['fas', 'spinner']" />
+            </div>
+
+            <ul v-else class="list_main_concert" id="perf_poster">
               <li
                 v-for="(item, index) in myLikes"
                 :key="index"
@@ -157,6 +162,8 @@ import { usePointStore } from '@/stores/usePointStore';
 import { useMyHeaderStore } from '@/stores/useMyHeaderStore';
 import MyExchangeComponent from './MyExchangeComponent.vue';
 
+const isLoading = ref(true);
+
 const exchangeListStore = useExchangeListStore();
 const programStore = useProgramsStore();
 const pointStore = usePointStore();
@@ -166,17 +173,44 @@ const myLikes = ref([]);
 
 // 컴포넌트가 마운트될 때 데이터 가져오기
 onMounted(async () => {
-  pointStore.reqType.getOrUse = 2; // reqType을 2로 설정
-  await exchangeListStore.getData(0);
-  await programStore.getMyReservations();
-  await pointStore.getPointData(); // reqType을 매개변수로 전달할 필요 없음
-  await myHeaderStore.getMyHeader();
+  try {
+    pointStore.reqType.getOrUse = 2; // reqType을 2로 설정
+    await exchangeListStore.getData(0);
+    await programStore.getMyReservations();
+    await pointStore.getPointData(); // reqType을 매개변수로 전달할 필요 없음
+    await myHeaderStore.getMyHeader();
 
-  myLikes.value = await programStore.getMyLikes();
+    myLikes.value = await programStore.getMyLikes();
+  } catch (error) {
+    console.log(error);
+  } finally {
+    isLoading.value = false;
+  }
 });
 </script>
 
 <style scoped>
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 36px;
+  color: #00b523;
+  animation: blink 1s infinite;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
 .foru {
   display: flex;
   justify-content: space-between;

--- a/src/components/mypage/MyPageComponent.vue
+++ b/src/components/mypage/MyPageComponent.vue
@@ -82,7 +82,7 @@
                   <strong class="tit">{{ item.title }}</strong>
                   <span class="day">{{ item.date }}</span>
                   <span class="location">{{ item.location }}</span>
-                  <span class="stat">
+                  <span class="stat" @click.prevent="like(item.id)">
                     <font-awesome-icon :icon="['fas', 'heart']" />
                   </span>
                 </a>
@@ -187,9 +187,25 @@ onMounted(async () => {
     isLoading.value = false;
   }
 });
+
+const like = async (id) => {
+  try {
+    await programStore.like(id);
+
+    myLikes.value = await programStore.getMyLikes();
+  } catch (error) {
+    console.error('Failed to update likes:', error);
+  }
+};
 </script>
 
 <style scoped>
+.list_main_concert {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0px;
+}
+
 .loading {
   display: flex;
   justify-content: center;

--- a/src/components/mypage/MyPageComponent.vue
+++ b/src/components/mypage/MyPageComponent.vue
@@ -55,6 +55,36 @@
             </div>
           </div>
 
+          <div class="wrap_main_concert">
+            <div class="foru">
+              <h2 class="tit_main_concert">For u</h2>
+              <p>
+                더보기
+                <font-awesome-icon :icon="['fas', 'chevron-right']" />
+              </p>
+            </div>
+            <ul class="list_main_concert" id="perf_poster">
+              <li
+                v-for="(item, index) in myLikes"
+                :key="index"
+                :class="index === 0 ? 'first' : ''"
+              >
+                <a :href="`/detail/${item.id}`" class="inner">
+                  <span class="thumb">
+                    <img :src="item.imageUrl" :alt="item.imageUrl" />
+                    <span class="frame"></span>
+                  </span>
+                  <strong class="tit">{{ item.title }}</strong>
+                  <span class="day">{{ item.date }}</span>
+                  <span class="location">{{ item.location }}</span>
+                  <span class="stat">
+                    <font-awesome-icon :icon="['fas', 'heart']" />
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </div>
+
           <div class="warp_ticket">
             <a>
               <h2 class="tit_sub_float">최근 예매/취소</h2>
@@ -118,7 +148,7 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, ref } from 'vue';
 import { useExchangeListStore } from '@/stores/useExchangeListStore.js';
 import { useProgramsStore } from '@/stores/useProgramsStore';
 import MyReservationComponent from './MyReservationComponent.vue';
@@ -132,6 +162,8 @@ const programStore = useProgramsStore();
 const pointStore = usePointStore();
 const myHeaderStore = useMyHeaderStore();
 
+const myLikes = ref([]);
+
 // 컴포넌트가 마운트될 때 데이터 가져오기
 onMounted(async () => {
   pointStore.reqType.getOrUse = 2; // reqType을 2로 설정
@@ -139,10 +171,25 @@ onMounted(async () => {
   await programStore.getMyReservations();
   await pointStore.getPointData(); // reqType을 매개변수로 전달할 필요 없음
   await myHeaderStore.getMyHeader();
+
+  myLikes.value = await programStore.getMyLikes();
 });
 </script>
 
 <style scoped>
+.foru {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.foru p {
+  color: gray;
+  margin-right: 5px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
 .scrollable {
   height: 400px;
   overflow-y: auto;
@@ -584,6 +631,7 @@ table .btn_flexible {
   background-position: right -110px;
   padding-right: 8px;
   color: #00b523;
+  display: flex;
 }
 .btn_flexible_ico1 span,
 .btn_flexible_ico2 span,
@@ -595,5 +643,14 @@ table .btn_flexible {
   line-height: 18px;
   text-align: center;
   vertical-align: top;
+}
+
+.wrap_main_concert .list_main_concert .stat {
+  display: flex;
+  justify-content: end;
+}
+
+.wrap_main_concert .list_main_concert li {
+  margin-top: 10px;
 }
 </style>

--- a/src/components/mypage/MyPageComponent.vue
+++ b/src/components/mypage/MyPageComponent.vue
@@ -4,6 +4,7 @@
       <div id="conts_section" class="pr_none">
         <div id="conts" class="clear_g">
           <h2 class="screen_out">마이티켓</h2>
+
           <div class="wrap_person">
             <div class="box_person_info">
               <div class="thumb">
@@ -53,6 +54,7 @@
               </ul>
             </div>
           </div>
+
           <div class="warp_ticket">
             <a>
               <h2 class="tit_sub_float">최근 예매/취소</h2>
@@ -62,15 +64,6 @@
             </div>
             <div class="box_ticket_list" id="divFound">
               <table summary="최근 예매/취소 리스트" class="tbl tbl_style02">
-                <caption class="hide"></caption>
-                <colgroup>
-                  <!-- 카카오페이 추가 -->
-                  <col width="149" />
-                  <col width="470" />
-                  <col width="233" />
-                  <col width="154" />
-                  <!-- 카카오페이 추가 -->
-                </colgroup>
                 <thead>
                   <tr>
                     <th>상태</th>

--- a/src/stores/useProgramsStore.js
+++ b/src/stores/useProgramsStore.js
@@ -94,5 +94,16 @@ export const useProgramsStore = defineStore('programs', {
         this.program.like = currentLikeStatus;
       }
     },
+
+    async getMyLikes() {
+      try {
+        const response = await axios.get(`/api/like/my?page=0&size=4`, {
+          withCredentials: true,
+        });
+        return response.data.result;
+      } catch (error) {
+        console.error('Failed to update like status:', error);
+      }
+    },
   },
 });


### PR DESCRIPTION
## 연관된 이슈
#2 
<br>

## 작업 내용
- 마이 페이지에서 내가 좋아요 한 공연 목록을 조회할 수 있도록 구현했습니다.
- 좋아요 공연 카드의 하트를 클릭하면 해당 항목이 좋아요 목록에서 삭제되도록 처리했습니다.
- 좋아요 공연 카드 클릭 시, 공연 상세보기 페이지로 이동하도록 구현했습니다.
- 더를 추가하여 데이터 로딩 중임을 표시해 사용자 경험을 개선했습니다.
- 목록이 4개 미만일 경우에도 항상 왼쪽에서부터 정렬되도록 스타일을 수정하고, 기본적으로 4개씩 표시되도록 설정했습니다.

<br> 

## 전달 사항
- 더보기 기능은 현재 미구현 상태입니다. chevron 버튼을 사용해 페이징 처리를 할지, 더보기 버튼으로 새 페이지를 로드할지, 또는 모달을 활용할지에 대한 추가적인 논의가 필요합니다.
