### PR TITLE
[Refactor] 좌석 선택 팝업창 수정 및 상세페이지 수정 [#3]

### DIFF
--- a/src/components/book/SeatComponent.vue
+++ b/src/components/book/SeatComponent.vue
@@ -55,6 +55,20 @@ watch(
   }
 );
 
+watch(
+  () => bookingStore.book.timesId,
+  async (newTimesId, oldTimesId) => {
+    if (newTimesId !== oldTimesId) {
+      resetSelectedSeat();
+      if (type.type == 'purchase') {
+        await bookingStore.getSeatLists();
+      } else if (type.type == 'exchange') {
+        await bookingStore.getExchangeSeatLists();
+      }
+    }
+  }
+);
+
 // 섹션 클릭 시 선택된 좌석 초기화
 const resetSelectedSeat = () => {
   if (selectedSeat.value) {

--- a/src/components/book/SeatComponent.vue
+++ b/src/components/book/SeatComponent.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="seating-area">
+    <div v-if="isLoading" class="loading">
+      <font-awesome-icon :icon="['fas', 'spinner']" />
+    </div>
     <div
+      v-else
       class="row"
       v-for="seatList in bookingStore.book.seatLists"
       :key="seatList.idx"
@@ -33,11 +37,19 @@ const bookingStore = useBookingStore();
 const selectedSeat = ref(null);
 const selectedSeatInfo = ref(null);
 
+const isLoading = ref(true);
+
 onMounted(async () => {
-  if (type.type == 'purchase') {
-    await bookingStore.getSeatLists();
-  } else if (type.type == 'exchange') {
-    await bookingStore.getExchangeSeatLists();
+  try {
+    if (type.type == 'purchase') {
+      await bookingStore.getSeatLists();
+    } else if (type.type == 'exchange') {
+      await bookingStore.getExchangeSeatLists();
+    }
+  } catch (error) {
+    console.log(error);
+  } finally {
+    isLoading.value = false;
   }
 });
 
@@ -46,10 +58,18 @@ watch(
   async (newSectionId, oldSectionId) => {
     if (newSectionId !== oldSectionId) {
       resetSelectedSeat();
-      if (type.type == 'purchase') {
-        await bookingStore.getSeatLists();
-      } else if (type.type == 'exchange') {
-        await bookingStore.getExchangeSeatLists();
+      isLoading.value = true;
+
+      try {
+        if (type.type == 'purchase') {
+          await bookingStore.getSeatLists();
+        } else if (type.type == 'exchange') {
+          await bookingStore.getExchangeSeatLists();
+        }
+      } catch (error) {
+        console.log(error);
+      } finally {
+        isLoading.value = false;
       }
     }
   }
@@ -60,10 +80,18 @@ watch(
   async (newTimesId, oldTimesId) => {
     if (newTimesId !== oldTimesId) {
       resetSelectedSeat();
-      if (type.type == 'purchase') {
-        await bookingStore.getSeatLists();
-      } else if (type.type == 'exchange') {
-        await bookingStore.getExchangeSeatLists();
+      isLoading.value = true;
+
+      try {
+        if (type.type == 'purchase') {
+          await bookingStore.getSeatLists();
+        } else if (type.type == 'exchange') {
+          await bookingStore.getExchangeSeatLists();
+        }
+      } catch (error) {
+        console.log(error);
+      } finally {
+        isLoading.value = false;
       }
     }
   }
@@ -106,6 +134,26 @@ const clickSeat = (e, seatInfo) => {
 </script>
 
 <style scoped>
+.loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 36px;
+  color: #00b523;
+  animation: blink 1s infinite;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
 .seating-area {
   display: flex;
   flex-direction: column;

--- a/src/components/book/SelectExchangeSeatComponent.vue
+++ b/src/components/book/SelectExchangeSeatComponent.vue
@@ -90,7 +90,8 @@
                           >
                             <span class="area_tit"
                               >{{ section.gradeName }} 석
-                              {{ section.sectionName }} 구역</span
+                              {{ section.sectionName }} 구역 /
+                              {{ section.remainingCount }} 석</span
                             >
                           </li>
                         </ul>

--- a/src/components/book/SelectSeatComponent.vue
+++ b/src/components/book/SelectSeatComponent.vue
@@ -105,8 +105,9 @@
                           >
                             <span class="area_tit"
                               >{{ section.gradeName }} 석
-                              {{ section.sectionName }} 구역</span
-                            >
+                              {{ section.sectionName }} 구역/
+                              {{ section.remainingCount }} 석
+                            </span>
                           </li>
                         </ul>
                       </div>
@@ -176,7 +177,6 @@ const bookingStore = useBookingStore();
 const selectedSeat = ref(null);
 const selectedSection = ref(bookingStore.sections[0]);
 
-
 onMounted(async () => {
   await bookingStore.getSection();
 });
@@ -186,7 +186,6 @@ const selectSection = (section) => {
 
   bookingStore.setSection(section.id);
 };
-
 
 const getData = (seatInfo) => {
   selectedSeat.value = seatInfo;
@@ -246,7 +245,7 @@ const next = () => {
   position: relative;
 }
 .section_onestop:after {
-  content: "";
+  content: '';
   display: block;
   clear: both;
 }
@@ -271,7 +270,7 @@ const next = () => {
 .select_tit {
   padding-bottom: 6px;
   font-weight: 700;
-  font-family: AppleSDGothicNeo-Regular, "맑은 고딕", "Malgun Gothic",
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic',
     sans-serif;
   font-size: 16px;
   color: #333;
@@ -382,7 +381,7 @@ const next = () => {
 .box_seat_top .tit_seat {
   position: relative;
   padding: 11px 0 0 28px;
-  font-family: AppleSDGothicNeo-Regular, "맑은 고딕", "Malgun Gothic",
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic',
     sans-serif;
   font-size: 16px;
   color: #404040;
@@ -434,7 +433,7 @@ const next = () => {
   background-color: #c8c8c8;
 }
 .wrap_seat .box_stage .stage span {
-  font-family: AppleSDGothicNeo-Regular, "맑은 고딕", "Malgun Gothic",
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic',
     sans-serif;
   font-size: 16px;
   color: #fff;
@@ -455,7 +454,7 @@ const next = () => {
 .seat_box .seat_btn {
   height: 35px;
   padding: 0 10px 0 30px;
-  font-family: AppleSDGothicNeo-Regular, "맑은 고딕", "Malgun Gothic",
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic',
     sans-serif;
   font-size: 16px;
   color: #fff;
@@ -844,8 +843,8 @@ const next = () => {
 .btn_flexible_ico2 span {
   background-position: right -130px;
   color: #666;
-  font-family: AppleSDGothicNeo-Regular, "돋움", Dotum, "맑은 고딕",
-    "Malgun Gothic", "Apple Gothic", sans-serif;
+  font-family: AppleSDGothicNeo-Regular, '돋움', Dotum, '맑은 고딕',
+    'Malgun Gothic', 'Apple Gothic', sans-serif;
 }
 .btn_flexible_ico1 span,
 .btn_flexible_ico2 span,

--- a/src/components/book/SelectSeatComponent.vue
+++ b/src/components/book/SelectSeatComponent.vue
@@ -15,12 +15,16 @@
               id="scheduleNo"
               name="scheduleNo"
               class="sel_cate"
-              onchange="selectSchedule(this.value);"
+              @change="selectSchedule($event.target.value)"
             >
-              <option value="100001" selected="selected">
-                2024.08.03 (토) 18:00
+              <option
+                v-for="(time, index) in difTime"
+                :key="time.id"
+                :value="time.id"
+                :selected="index === 0"
+              >
+                {{ formatOption(time.date) }}
               </option>
-              <option value="100002">2024.08.04 (일) 17:00</option>
             </select>
           </span>
         </h3>
@@ -171,14 +175,19 @@
 import { onMounted, ref } from 'vue';
 import SeatComponent from '../book/SeatComponent.vue';
 import { useBookingStore } from '@/stores/useBookingStore';
+import { useProgramsStore } from '@/stores/useProgramsStore';
 import { formatNumber } from '@/utils/formatPrice';
 
 const bookingStore = useBookingStore();
+const programStore = useProgramsStore();
 const selectedSeat = ref(null);
 const selectedSection = ref(bookingStore.sections[0]);
 
+const difTime = ref([]);
+
 onMounted(async () => {
   await bookingStore.getSection();
+  difTime.value = await programStore.times(bookingStore.book.programId);
 });
 
 const selectSection = (section) => {
@@ -198,6 +207,17 @@ const next = () => {
     selectedSeat.value.seatId,
     selectedSection.value.price
   );
+};
+
+const formatOption = (date) => {
+  const options = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    weekday: 'short',
+  };
+  const formattedDate = new Date(date).toLocaleDateString('ko-KR', options);
+  return `${formattedDate} `;
 };
 </script>
 

--- a/src/components/book/SelectSeatComponent.vue
+++ b/src/components/book/SelectSeatComponent.vue
@@ -15,14 +15,10 @@
               id="scheduleNo"
               name="scheduleNo"
               class="sel_cate"
+              v-model="currentTimesId"
               @change="selectSchedule($event.target.value)"
             >
-              <option
-                v-for="(time, index) in difTime"
-                :key="time.id"
-                :value="time.id"
-                :selected="index === 0"
-              >
+              <option v-for="time in difTime" :key="time.id" :value="time.id">
                 {{ formatOption(time.date) }}
               </option>
             </select>
@@ -182,11 +178,12 @@ const bookingStore = useBookingStore();
 const programStore = useProgramsStore();
 const selectedSeat = ref(null);
 const selectedSection = ref(bookingStore.sections[0]);
-
+const currentTimesId = ref(null);
 const difTime = ref([]);
 
 onMounted(async () => {
   await bookingStore.getSection();
+  currentTimesId.value = bookingStore.book.timesId;
   difTime.value = await programStore.times(bookingStore.book.programId);
 });
 
@@ -218,6 +215,15 @@ const formatOption = (date) => {
   };
   const formattedDate = new Date(date).toLocaleDateString('ko-KR', options);
   return `${formattedDate} `;
+};
+
+const selectSchedule = async (selectedId) => {
+  try {
+    currentTimesId.value = selectedId;
+    bookingStore.setTimesId(selectedId);
+  } catch (error) {
+    console.error('Error fetching schedule data:', error);
+  }
 };
 </script>
 

--- a/src/components/reservation/DetailViewComponent.vue
+++ b/src/components/reservation/DetailViewComponent.vue
@@ -299,8 +299,19 @@ const isLoggedIn = memberStore.isLoggedIn;
 const selectedDate = ref(null);
 const selectedRound = ref(null);
 const isHover = ref(false);
-const isBeforeOpenDate = ref(true);
-const inReservationPeriod = ref(false);
+
+const now = new Date();
+
+const isBeforeOpenDate = computed(() => {
+  const openDate = new Date(programsStore.program.reservationOpenDate);
+  return now < openDate;
+});
+
+const inReservationPeriod = computed(() => {
+  const openDate = new Date(programsStore.program.reservationOpenDate);
+  const endDate = new Date(programsStore.program.programEndDate);
+  return now >= openDate && now < endDate;
+});
 
 onMounted(async () => {
   const programId = route.params.id;
@@ -309,14 +320,6 @@ onMounted(async () => {
     programsStore.PriceInfo(programId),
     programsStore.times(programId),
   ]);
-
-  // 프로그램 데이터가 로드된 후에 계산
-  const now = new Date();
-  isBeforeOpenDate.value =
-    now < new Date(programsStore.program.reservationOpenDate);
-  inReservationPeriod.value =
-    now >= new Date(programsStore.program.reservationOpenDate) &&
-    now < new Date(programsStore.program.programEndDate);
 });
 
 const enabledDates = computed(() => {

--- a/src/components/reservation/DetailViewComponent.vue
+++ b/src/components/reservation/DetailViewComponent.vue
@@ -28,16 +28,16 @@
                     <p
                       class="like"
                       @click="isLoggedIn && programsStore.like(route.params.id)"
-                      :class="{ disabled: !isLoggedIn, clickable: isLoggedIn }"
+                      :class="{
+                        disabled: !isLoggedIn,
+                        clickable: isLoggedIn,
+                        liked: programsStore.program.like,
+                      }"
                     >
                       <font-awesome-icon
                         v-if="programsStore.program.like"
                         :icon="['fas', 'heart']"
-                        style="
-                          padding-right: 10px;
-                          font-size: 20px;
-                          color: #db0000;
-                        "
+                        style="padding-right: 10px; font-size: 20px"
                       />
                       <font-awesome-icon
                         v-else
@@ -435,6 +435,11 @@ function formatTime(dateString) {
   padding-right: 16px;
   font-weight: 600;
   color: #686868;
+}
+
+.like.liked {
+  color: #00cd3c;
+  border: 2px solid #00cd3c;
 }
 
 #calender {

--- a/src/components/reservation/DetailViewComponent.vue
+++ b/src/components/reservation/DetailViewComponent.vue
@@ -377,7 +377,7 @@ const openPopup = () => {
     programsStore.program.programName,
     programId,
     timesId,
-    1
+    programsStore.program.firstSectionId
   );
 
   const popUrl = '/seat';

--- a/src/stores/useBookingStore.js
+++ b/src/stores/useBookingStore.js
@@ -27,6 +27,10 @@ export const useBookingStore = defineStore('booking', {
       this.book.sectionId = sectionId;
     },
 
+    setTimesId(timesId) {
+      this.book.timesId = timesId;
+    },
+
     async getSeatLists() {
       const res = await axios.post(
         '/api/seat/all',

--- a/src/stores/useBookingStore.js
+++ b/src/stores/useBookingStore.js
@@ -68,8 +68,6 @@ export const useBookingStore = defineStore('booking', {
         { withCredentials: true }
       );
 
-      console.log(res.data);
-
       if (res.status == 200) {
         if (res.data.code === 5000) {
           alert('이미 선택된 좌석입니다. 다른 좌석을 선택해주세요.');

--- a/src/stores/useProgramsStore.js
+++ b/src/stores/useProgramsStore.js
@@ -41,6 +41,8 @@ export const useProgramsStore = defineStore('programs', {
       try {
         const response = await axios.get(`/api/times/${programId}/seq`);
         this.times = response.data.result;
+
+        return this.times;
       } catch (error) {
         console.error('Failed times:', error);
       }


### PR DESCRIPTION
## 연관된 이슈
#3 
<br>

## 작업 내용
- 각 구역의 잔여 좌석 정보를 화면에 표시하여 사용자가 좌석 선택 시 참고할 수 있도록 기능을 추가했습니다.
- 기본 UI 디자인 가이드에 맞춰 상세페지지의 좋아요 버튼 스타일을 수정했습니다.
- 기존에 하드코딩되어 있던 예매 팝업창의 드롭다운 메뉴의 옵션 값을 실제 데이터를 기반으로 동적으로 렌더링하도록 수정했습니다.
- 드롭다운 메뉴에서 현재 선택된 회차가 기본 값으로 나타나도록 구현하여 사용자 편의성을 높였습니다.
- 데이터 로드 중 로딩 상태를 표시하는 Loader UI를 추가하여 사용자에게 명확한 상태를 전달하고, 사용자 경험을 개선했습니다.
- 예매 오픈 상태와 예약 가능 기간 계산 로직을 computed로 변경하여 비동기 데이터 로드 시 발생하던 초기 상태 오류를 해결했습니다.
- 예매 팝업 오픈 시 sectionId가 하드코딩되어 있어 첫 오픈 시 좌석 정보를 제대로 로드하지 못하는 문제가 있었습니다. 해당 데이터를 적절히 전달하도록 수정하여 좌석 렌더링 오류를 해결했습니다.
<br> 

## 전달 사항
close #3 
