### PR TITLE
[Feat] 카테고리별 페이지 구현 [#13]

### DIFF
--- a/src/components/common/HeaderComponent.vue
+++ b/src/components/common/HeaderComponent.vue
@@ -51,6 +51,7 @@
               v-model="searchKeyword"
               class="placeholder"
               placeholder="검색어를 입력하세요"
+              @keyup.enter="performSearch"
             />
             <button
               type="button"
@@ -64,7 +65,7 @@
           </fieldset>
         </div>
       </div>
-      <div id="gnb_menu">a
+      <div id="gnb_menu">
         <ul class="list_gnb">
           <li class="nth1">
             <router-link class="btn_gnb_menu btn_gnb btn_g_menu01" to="/"
@@ -72,14 +73,28 @@
             >
           </li>
           <li class="nth2">
-            <a class="btn_gnb_menu btn_gnb btn_g_menu02">콘서트</a>
+            <a
+              class="btn_gnb_menu btn_gnb btn_g_menu02"
+              @click="navigateWithReload('/category/2')"
+            >
+              콘서트
+            </a>
           </li>
           <li class="nth3">
-            <a class="btn_gnb_menu btn_gnb btn_g_menu03">뮤지컬/연극</a>
+            <a
+              class="btn_gnb_menu btn_gnb btn_g_menu03"
+              @click="navigateWithReload('/category/1')"
+            >
+              뮤지컬/연극
+            </a>
           </li>
-
           <li class="nth10">
-            <a class="btn_gnb_menu btn_gnb btn_g_menu10">클래식</a>
+            <a
+              class="btn_gnb_menu btn_gnb btn_g_menu10"
+              @click="navigateWithReload('/category/3')"
+            >
+              클래식
+            </a>
           </li>
           <li class="nth9">
             <router-link class="btn_gnb_menu btn_gnb btn_g_menu09" to="/mypage"
@@ -109,14 +124,14 @@
 </template>
 
 <script>
-import { mapStores } from 'pinia';
-import { useMemberStore } from '@/stores/useMemberStore.js';
+import { mapStores } from "pinia";
+import { useMemberStore } from "@/stores/useMemberStore.js";
 
 export default {
-  name: 'HeaderComponent',
+  name: "HeaderComponent",
   data() {
     return {
-      searchKeyword: '', // 검색어 저장
+      searchKeyword: "",
     };
   },
   computed: {
@@ -125,11 +140,18 @@ export default {
   methods: {
     performSearch() {
       if (this.searchKeyword.trim()) {
-        // 검색어가 입력된 경우에만 이동
-        this.$router.push({ path: '/search', query: { keyword: this.searchKeyword } });
+        this.$router.push({
+          path: "/search",
+          query: { keyword: this.searchKeyword },
+        });
       } else {
-        alert('검색어를 입력하세요.');
+        alert("검색어를 입력하세요.");
       }
+    },
+    navigateWithReload(path) {
+      this.$router.push(path).then(() => {
+        window.location.reload();
+      });
     },
   },
 };
@@ -204,8 +226,8 @@ button,
 input {
   font-size: 12px;
   line-height: 1.5;
-  font-family: AppleSDGothicNeo-Regular, '돋움', Dotum, '맑은 고딕',
-    'Malgun Gothic', 'Apple Gothic', sans-serif;
+  font-family: AppleSDGothicNeo-Regular, "돋움", Dotum, "맑은 고딕",
+    "Malgun Gothic", "Apple Gothic", sans-serif;
   color: #666;
   letter-spacing: -1px;
 }
@@ -255,7 +277,7 @@ button {
   height: 0;
   font-size: 0;
   clear: both;
-  content: '';
+  content: "";
 }
 .btn_comm {
   display: block;
@@ -484,7 +506,7 @@ button {
     top center repeat-x;
 }
 #header:after {
-  content: '';
+  content: "";
   display: block;
   clear: both;
 }
@@ -500,7 +522,7 @@ button {
   height: 112px;
 }
 #header_wrap #gnb:after {
-  content: '';
+  content: "";
   display: block;
   clear: both;
 }

--- a/src/components/main/CategoryComponent.vue
+++ b/src/components/main/CategoryComponent.vue
@@ -1,0 +1,687 @@
+<template>
+  <div id="conts" class="clear_g">
+    <div class="wrap_main_concert">
+      <div class="category-header">
+        <h2 class="tit_main_concert">장르별 공연</h2>
+        <p class="category-description">
+          {{ categoryName }} 카테고리에서 선택된 최고의 공연을 만나보세요.
+        </p>
+      </div>
+
+      <ul class="list_main_concert" id="perf_poster">
+        <CardComponent
+          v-for="program in programsStore.programs"
+          :key="program.programId"
+          :program="program"
+        />
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapStores } from 'pinia';
+import { useProgramsStore } from '@/stores/useProgramsStore.js';
+import CardComponent from './CardComponent.vue';
+import { useRoute } from 'vue-router';
+
+export default {
+  name: 'CategoryComponent',
+  components: { CardComponent },
+  data() {
+    return {
+      categoryId: null,
+    };
+  },
+  computed: {
+    ...mapStores(useProgramsStore),
+
+    categoryName() {
+      const categories = { 1: '콘서트', 2: '뮤지컬/연극', 3: '클래식' };
+      return categories[this.categoryId] || '기타';
+    },
+  },
+  async mounted() {
+    const route = useRoute();
+    this.categoryId = parseInt(route.params.categoryId);
+
+    if (this.categoryId) {
+      try {
+        await this.programsStore.getCategoryPrograms(this.categoryId);
+      } catch (error) {
+        console.error('Error loading category programs:', error);
+      }
+    }
+  },
+};
+</script>
+
+<style>
+body,
+div,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+li,
+ul {
+  margin: 0;
+  padding: 0;
+}
+html {
+  scrollbar-3dlight-color: #e1e1e1;
+  scrollbar-base-color: #e1e1e1;
+  scrollbar-face-color: #e1e1e1;
+  scrollbar-highlight-color: #e1e1e1;
+  scrollbar-shadow-color: #e1e1e1;
+  scrollbar-darkshadow-color: #e1e1e1;
+  scrollbar-arrow-color: #fff;
+  scrollbar-track-color: #eee;
+}
+::-webkit-scrollbar {
+  width: 16px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: #eee;
+}
+::-webkit-scrollbar-thumb {
+  height: 10px;
+  width: 16px;
+  background: #e1e1e1;
+  -webkit-box-shadow: #e1e1e1;
+}
+img {
+  border: 0 none;
+}
+li,
+ul {
+  list-style: none;
+}
+body {
+  background: #fff;
+  -webkit-text-size-adjust: none;
+}
+body {
+  font-size: 12px;
+  line-height: 1.5;
+  font-family: AppleSDGothicNeo-Regular, '돋움', Dotum, '맑은 고딕',
+    'Malgun Gothic', 'Apple Gothic', sans-serif;
+  color: #666;
+  letter-spacing: -1px;
+}
+a {
+  color: #666;
+  text-decoration: none;
+}
+.clear_g {
+  display: block;
+  overflow: visible;
+  width: auto;
+  clear: both;
+}
+.clear_g:after {
+  display: block;
+  visibility: hidden;
+  height: 0;
+  font-size: 0;
+  clear: both;
+  content: '';
+}
+.ac {
+  text-align: center;
+}
+.thumb_117x117,
+.thumb_130x180,
+.thumb_130x184,
+.thumb_135x135,
+.thumb_160x225,
+.thumb_180x250,
+.thumb_190x142,
+.thumb_234x176,
+.thumb_238x178,
+.thumb_250x250,
+.thumb_268x120,
+.thumb_268x155,
+.thumb_280x166,
+.thumb_314x235,
+.thumb_320x400,
+.thumb_339x328,
+.thumb_340x328,
+.thumb_545x150,
+.thumb_660x328,
+.thumb_661x328,
+.thumb_90x125,
+.thumb_90x90 {
+  display: block;
+  overflow: hidden;
+  position: relative;
+}
+.thumb_190x142 .frame,
+.thumb_238x178 .frame,
+.thumb_268x120 .frame,
+.thumb_268x155 .frame,
+.thumb_314x235 .frame,
+.thumb_545x150 .frame,
+.thumb_90x90 .frame {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: url(//cdnticket.melon.co.kr/resource/image/web/common/bg_frame3.png)
+    no-repeat;
+}
+.thumb_117x117 .frame,
+.thumb_135x135 .frame,
+.thumb_234x176 .frame,
+.thumb_250x250 .frame,
+.thumb_280x166 .frame,
+.thumb_339x328 .frame,
+.thumb_340x328 .frame,
+.thumb_660x328 .frame,
+.thumb_661x328 .frame {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: url(//cdnticket.melon.co.kr/resource/image/web/common/bg_frame2.png)
+    no-repeat;
+  z-index: 99;
+}
+.thumb_130x180 .frame,
+.thumb_130x184 .frame,
+.thumb_160x225 .frame,
+.thumb_180x250 .frame,
+.thumb_320x400 .frame,
+.thumb_90x125 .frame {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: url(//cdnticket.melon.co.kr/resource/image/web/common/bg_frame.png)
+    no-repeat;
+}
+.thumb_545x150,
+.thumb_545x150 .frame {
+  width: 545px;
+  height: 150px;
+}
+.thumb_268x155,
+.thumb_268x155 .frame {
+  width: 268px;
+  height: 155px;
+}
+.thumb_190x142,
+.thumb_190x142 .frame {
+  width: 190px;
+  height: 142px;
+}
+.thumb_314x235,
+.thumb_314x235 .frame {
+  width: 314px;
+  height: 235px;
+}
+.thumb_238x178,
+.thumb_238x178 .frame {
+  width: 238px;
+  height: 178px;
+}
+.thumb_339x328,
+.thumb_339x328 .frame {
+  width: 339px;
+  height: 328px;
+}
+.thumb_340x328,
+.thumb_340x328 .frame {
+  width: 340px;
+  height: 328px;
+}
+.thumb_660x328,
+.thumb_660x328 .frame {
+  width: 660px;
+  height: 328px;
+}
+.thumb_661x328,
+.thumb_661x328 .frame {
+  width: 661px;
+  height: 328px;
+}
+.thumb_250x250,
+.thumb_250x250 .frame {
+  width: 250px;
+  height: 250px;
+}
+.thumb_117x117,
+.thumb_117x117 .frame {
+  width: 117px;
+  height: 117px;
+}
+.thumb_135x135,
+.thumb_135x135 .frame {
+  width: 135px;
+  height: 135px;
+}
+.thumb_280x166,
+.thumb_280x166 .frame {
+  width: 280px;
+  height: 166px;
+}
+.thumb_268x120,
+.thumb_268x120 .frame {
+  width: 268px;
+  height: 120px;
+}
+.thumb_234x176,
+.thumb_234x176 .frame {
+  width: 234px;
+  height: 176px;
+}
+.thumb_320x400,
+.thumb_320x400 .frame {
+  width: 320px;
+  height: 400px;
+}
+.thumb_180x250,
+.thumb_180x250 .frame {
+  width: 180px;
+  height: 250px;
+}
+.thumb_160x225,
+.thumb_160x225 .frame {
+  width: 160px;
+  height: 225px;
+}
+.thumb_130x180,
+.thumb_130x180 .frame {
+  width: 130px;
+  height: 180px;
+}
+.thumb_90x125,
+.thumb_90x125 .frame {
+  width: 90px;
+  height: 125px;
+}
+.thumb_90x90,
+.thumb_90x90 .frame {
+  width: 90px;
+  height: 90px;
+}
+.thumb_130x184,
+.thumb_130x184 .frame {
+  width: 130px;
+  height: 184px;
+}
+.thumb_545x150 .frame {
+  background-position: -190px -413px;
+}
+.thumb_268x155 .frame {
+  background-position: -732px 0;
+}
+.thumb_190x142 .frame {
+  background-position: 0 -413px;
+}
+.thumb_238x178 .frame {
+  background-position: 0 -235px;
+}
+.thumb_314x235 .frame {
+  background-position: 0 0;
+}
+.thumb_339x328 .frame {
+  background: 0 0;
+  background-color: #000;
+  opacity: 0.5;
+}
+.thumb_340x328 .frame {
+  background: 0 0;
+  background-color: #000;
+  opacity: 0.5;
+}
+.thumb_660x328 .frame {
+  background: 0 0;
+  background-color: #000;
+  opacity: 0.25;
+}
+.thumb_661x328 .frame {
+  background: 0 0;
+  background-color: #000;
+  opacity: 0.25;
+}
+.thumb_250x250 .frame {
+  background-position: 0 -523px;
+}
+.thumb_117x117 .frame {
+  background: 0 0;
+  width: 115px;
+  height: 115px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_135x135 .frame {
+  background: 0 0;
+  width: 133px;
+  height: 133px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_280x166 .frame {
+  background-position: 0 -356px;
+}
+.thumb_268x120 .frame {
+  background: 0 0;
+  width: 266px;
+  height: 118px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_234x176 .frame {
+  background: 0 0;
+  width: 232px;
+  height: 174px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_320x400 .frame {
+  background-position: -650px -500px;
+}
+.thumb_180x250 .frame {
+  background: 0 0;
+  width: 178px;
+  height: 248px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_160x225 .frame {
+  background: 0 0;
+  width: 158px;
+  height: 223px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_130x180 .frame {
+  background: 0 0;
+  width: 128px;
+  height: 178px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_90x125 .frame {
+  background: 0 0;
+  width: 88px;
+  height: 123px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_90x90 .frame {
+  background-position: 0 -740px;
+}
+.thumb_130x184 .frame {
+  background: 0 0;
+  width: 128px;
+  height: 182px;
+  z-index: 10;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.thumb_117x117 img,
+.thumb_130x180 img,
+.thumb_130x184 img,
+.thumb_135x135 img,
+.thumb_160x225 img,
+.thumb_180x250 img,
+.thumb_190x142 img,
+.thumb_234x176 img,
+.thumb_238x178 img,
+.thumb_268x120 img,
+.thumb_268x155 img,
+.thumb_280x166 img,
+.thumb_314x235 img,
+.thumb_320x400 img,
+.thumb_339x328 img,
+.thumb_340x328 img,
+.thumb_545x150 img,
+.thumb_660x328 img,
+.thumb_661x328 img,
+.thumb_90x125 img,
+.thumb_90x90 img {
+  vertical-align: top;
+}
+#conts {
+  display: block;
+  position: relative;
+  width: 1008px;
+  min-height: 600px;
+  padding: 0 20px 53px;
+  margin: 0 auto;
+}
+#conts:after {
+  content: '';
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  height: 0;
+  text-align: -9999px;
+  clear: both;
+}
+.index #conts {
+  padding-top: 0;
+}
+.wrap_main_performance {
+  display: block;
+  overflow: hidden;
+  margin-top: 30px;
+  border: 1px solid #ddd;
+}
+.category-header {
+  text-align: center;
+  margin-bottom: 20px;
+}
+.category-description {
+  font-size: 16px;
+  color: #666;
+  margin-top: 8px;
+}
+
+.wrap_main_performance .list_main_performance {
+  display: block;
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding: 73px 0 23px;
+}
+.wrap_main_performance .list_main_performance .tit {
+  position: absolute;
+  top: 0;
+  height: 48px;
+  border-left: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  background-color: #eee;
+}
+.wrap_main_performance .list_main_performance .tit a {
+  display: block;
+  height: 48px;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 48px;
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic';
+  color: #333;
+  text-align: center;
+}
+.wrap_main_performance .list_main_performance .tit a:hover {
+  text-decoration: none;
+  color: #000;
+}
+.wrap_main_concert {
+  padding-top: 28px;
+}
+.wrap_main_concert .tit_main_concert {
+  display: block;
+  padding-bottom: 16px;
+  font-size: 20px;
+  line-height: 28px;
+  font-family: AppleSDGothicNeo-Regular, '맑은 고딕', 'Malgun Gothic';
+  color: #333;
+}
+.wrap_main_concert .list_main_concert {
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  margin-top: -30px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+.wrap_main_concert .list_main_concert li {
+  float: left;
+  margin-left: 28px;
+  padding-top: 30px;
+}
+.wrap_main_concert .list_main_concert li.first {
+  margin-left: 0;
+  padding-right: 1px;
+}
+.wrap_main_concert .list_main_concert .inner {
+  position: relative;
+  display: block;
+  width: 180px;
+  height: 358px;
+  padding: 24px 24px 21px;
+  border: 1px solid #eee;
+}
+.wrap_main_concert .list_main_concert .inner:hover {
+  text-decoration: none;
+}
+.wrap_main_concert .list_main_concert .thumb {
+  display: block;
+  position: relative;
+  width: 180px;
+  height: 250px;
+  overflow: hidden;
+}
+.wrap_main_concert .list_main_concert .thumb img {
+  width: 180px;
+}
+.wrap_main_concert .list_main_concert .thumb .frame {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 178px;
+  height: 248px;
+  background: 0 0;
+  z-index: 10;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+.wrap_main_concert .list_main_concert .inner:hover .thumb .frame {
+  background-position: -820px -230px;
+}
+.wrap_main_concert .list_main_concert .tit {
+  display: block;
+  overflow: hidden;
+  height: 20px;
+  padding: 13px 0 9px;
+  font-size: 16px;
+  line-height: 20px;
+  color: #333;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wrap_main_concert .list_main_concert .inner:hover .tit {
+  color: #000;
+}
+.wrap_main_concert .list_main_concert .inner:hover .day {
+  color: #000;
+}
+.wrap_main_concert .list_main_concert .inner:hover .location {
+  color: #000;
+}
+.wrap_main_concert .list_main_concert .day {
+  display: block;
+  overflow: hidden;
+  height: 18px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  color: #666;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wrap_main_concert .list_main_concert .location {
+  display: block;
+  overflow: hidden;
+  height: 20px;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 20px;
+  color: #888;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wrap_main_concert .list_main_concert .stat {
+  display: block;
+  overflow: hidden;
+  height: 20px;
+  padding-top: 8px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 20px;
+  color: #00cd3c;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.thumb_180x254 {
+  width: 180px;
+  height: 254px;
+  position: relative;
+}
+.thumb_180x254 .frame {
+  position: absolute;
+  width: 178px;
+  height: 252px;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  border: 1px solid #000;
+  opacity: 0.03;
+}
+@-moz-document url-prefix() {
+  .btn_arr_down_28 {
+    height: 28px;
+    padding: 0 20px 0 0;
+    background-position: right -675px;
+  }
+  .btn_arr_down_28 span {
+    padding: 6px 0 0 7px;
+    background-position: left -675px;
+    margin-top: -1px;
+    height: 22px;
+  }
+  .btn_arr_down_28:hover span {
+    background-position: left -1184px;
+  }
+  .ico_list {
+    line-height: 15px;
+  }
+  .ico_list4 {
+    line-height: 15px;
+  }
+}
+</style>

--- a/src/components/main/SearchComponent.vue
+++ b/src/components/main/SearchComponent.vue
@@ -163,6 +163,15 @@ body {
   color: #666;
   letter-spacing: -1px;
 }
+a.inner {
+  color: black; 
+  text-decoration: none;
+}
+
+a.inner:hover {
+  color: black;
+  text-decoration: underline;
+}
 a {
   color: #666;
   text-decoration: none;

--- a/src/pages/CategoryPage.vue
+++ b/src/pages/CategoryPage.vue
@@ -1,0 +1,22 @@
+<template>
+  <HeaderComponent />
+  <CategoryComponent />
+  <FooterComponent />
+</template>
+
+<script>
+import HeaderComponent from '../components/common/HeaderComponent.vue';
+import FooterComponent from '../components/common/FooterComponent.vue';
+import CategoryComponent from '@/components/main/CategoryComponent.vue';
+
+export default {
+  name: 'CategoryPage',
+  components: {
+    CategoryComponent,
+    HeaderComponent,
+    FooterComponent,
+  },
+};
+</script>
+
+<style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,8 @@ import SignupComponent from '@/components/auth/SignupComponent.vue';
 import ReservationPage from '@/pages/ReservationPage.vue';
 import DeatilProgramPage from '@/pages/DeatilProgramPage.vue';
 import SearchPage from '@/pages/SearchPage.vue';
+import CategoryPage from '@/pages/CategoryPage.vue';
+import { useProgramsStore } from '@/stores/useProgramsStore';
 
 const requireLogin = async (to, from, next) => {
   const memberStore = useMemberStore();
@@ -80,7 +82,25 @@ const router = createRouter({
       path: '/search',
       component: SearchPage,
       props: (route) => ({ keyword: route.query.keyword }),
+    },
+    {
+      path: '/category/:categoryId',
+      component: CategoryPage,
+      props: true, // categoryId를 props로 전달
+      beforeEnter: async (to, from, next) => {
+        const programsStore = useProgramsStore();
+        const categoryId = to.params.categoryId;
+    
+        try {
+          await programsStore.getCategoryPrograms(categoryId);
+          next();
+        } catch (error) {
+          console.error('Failed to load category data:', error);
+          next(false);
+        }
+      },
     }
+    
   ],
 });
 

--- a/src/stores/useProgramsStore.js
+++ b/src/stores/useProgramsStore.js
@@ -41,6 +41,18 @@ export const useProgramsStore = defineStore('programs', {
       }
     },
 
+    async getCategoryPrograms(categoryId, page = 0, size = 12) {
+      try {
+        const response = await axios.get(
+          `/api/program/readCategory?categoryId=${categoryId}&page=${page}&size=${size}`
+        );
+        this.programs = response.data.result;
+      } catch (error) {
+        console.error('Error fetching category programs:', error);
+        throw error;
+      }
+    },
+
     async PriceInfo(programId) {
       try {
         const response = await axios.get(`/api/price?programId=${programId}`);


### PR DESCRIPTION
## 연관된 이슈
#13 
<br>

## 작업 내용
- 헤더에 있는 카테고리 상자를 눌렀을 때, 해당 카테고리 별로 공연이 나눠지는 페이지를 구현했습니다.
  - 상자를 눌렀을 때, url은 변경 되지만 새로고침이 되지 않아 내용이 바뀌지 않음을 확인하고 `navigateWithReload`을 넣어 라우팅 후 새로고침이 가능하도록 했습니다.
- 검색 페이지 코멘트 확인하여 a 태그 css를 수정하였고, 엔터를 눌렀을 때 이동 되도록 `@keyup.enter="performSearch"` 을 추가 했습니다.

<br> 

## 전달 사항

무한 스크롤 및 페이징 처리는 메인과 카테고리, 검색페이지 한 번에 구현하기 위해 아직 남겨둔 상태입니다.
새로운 브랜치를 파서 한 번에 구현하도록 하겠습니다~!! 🥰

지금 DB에 있는 카테고리 이름과 프론트 화면이 맞지 않아 나중에 데이터 값 수정해야 할 것 같습니다!
